### PR TITLE
Add ZeroUnit linter and tests.

### DIFF
--- a/src/Linters/ZeroUnit.js
+++ b/src/Linters/ZeroUnit.js
@@ -1,0 +1,50 @@
+import Linter from './Linter';
+import includes from 'lodash/collection/includes';
+
+const  LENGTH_UNITS = ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'in', 'pt', 'pc', 'px'];
+
+const ZERO_UNIT_REGEX = /\b(0[a-z]+)\b/ig;
+
+/**
+ * @class ZeroUnit
+ *
+ * Checks for unnecessary units on zero values.
+ */
+class ZeroUnit extends Linter {
+
+    /**
+     * Types of nodes that this linter is interested in.
+     * @see https://github.com/DFurnes/sasstree/tree/master/src/Nodes
+     * @type {Array}
+     */
+    nodeTypes = ['Declaration', 'AtRule'];
+
+    /**
+     * Default options.
+     * @type {object}
+     */
+    defaults = {
+        severity: 'warning',
+    };
+
+    run(node) {
+        // @TODO: This can be cleaned up when SassTree parses numbers
+        const matches = node.value.match(ZERO_UNIT_REGEX);
+        if(matches) {
+            matches.forEach((val) => {
+                // Don't report lint if this is a `.0` fractional number
+                if(node.value[node.value.indexOf(val) - 1] === '.') return;
+
+                // Only lint unitless zero on units that can be unitless
+                LENGTH_UNITS.forEach((UNIT) => {
+                    if(includes(val, UNIT)) {
+                        this.error(node, `'${val}' should be written without units as '0'`)
+                    }
+                });
+            });
+        }
+    }
+
+}
+
+export default ZeroUnit;

--- a/tests/.sasslint.json
+++ b/tests/.sasslint.json
@@ -9,6 +9,9 @@
     },
     "SpaceAfterPropertyColon": {
       "enabled": true
+    },
+    "ZeroUnit": {
+      "enabled": true
     }
   }
 }

--- a/tests/input.scss
+++ b/tests/input.scss
@@ -17,7 +17,7 @@
 
 .thing:before {
   content: 'Hi!';
-  border: 0;
+  border: 0px;
   border-right: none;
 }
 

--- a/tests/rules/ZeroUnit.js
+++ b/tests/rules/ZeroUnit.js
@@ -1,0 +1,26 @@
+import test from 'tape-catch';
+import '../assertions';
+
+const { raw } = String;
+
+test('ZeroUnit', function(t) {
+    t.plan(11);
+
+    const defaults = {
+        'ZeroUnit': {
+            enabled: true,
+        }
+    };
+
+    t.isValid(defaults, 'p {}', 'when no properties exist');
+    t.isValid(defaults, 'p { margin: 0; }', 'when properties with unit-less zeros exist');
+    t.isValid(defaults, 'p { margin: 5px; line-height: 1.5em; }', 'when properties with non-zero values exist');
+    t.isInvalid(defaults, 'p { margin: 0px; }', 'when properties with zero values contain units');
+    t.isInvalid(defaults, 'p { margin: 5em 0em 2em 0px; }', 'when properties with multiple zero values containing units exist');
+    t.isInvalid(defaults, 'p { margin: some-function(0em); }', 'when function call contains a zero value with units');
+    t.isInvalid(defaults, 'p { @include some-mixin(0em); }', 'when mixin include contains a zero value with units');
+    t.isValid(defaults, 'p { content: func("0em"); }', 'when string contains a zero value with units');
+    t.isValid(defaults, 'p { margin: 4.0em; }', 'when property value has a ".0" fractional component');
+    t.isValid(defaults, 'p { color: #0af; }', 'when property value has a color hex with a leading 0');
+    t.isValid(defaults, 'p { transition-delay: 0s; }', 'when property with zero value is a dimension');
+});


### PR DESCRIPTION
# Changes

Adds **ZeroUnit** linter, which checks for extraneous units on zero values (e.g. `0px` rather than `0`).

One test currently fails because I'm naively working on value strings, rather than using tokenized Sass values. I _think_ this could be fixed in the linter, but it's probably better to just beef up Sasstree and leave this as a failure for now.
