### PR TITLE
Add commander to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.1.0",
+    "commander": "^2.8.1",
     "find-parent-dir": "^0.3.0",
     "lodash": "^3.3.1",
     "sasstree": "0.0.9",


### PR DESCRIPTION
Commander is required by `src/Console.js` but it's not installed as a dependency.
